### PR TITLE
Simplify Project Retrieval

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -1,16 +1,12 @@
 import asyncHandler from 'express-async-handler';
 import { projectService, statusService, tagService } from '../services';
-import { ISortQuery } from '../types';
 import {
-  BAD_REQUEST,
   CREATED,
-  DB_COLUMNS,
   NO_CONTENT,
   OK,
   paramsSchema,
   projectSchema,
   projectUpdateSchema,
-  sortSchema,
 } from '../utils';
 
 export const createProject = asyncHandler(async (req, res) => {
@@ -45,29 +41,9 @@ export const getProject = asyncHandler(async (req, res) => {
 });
 
 export const getAllProjects = asyncHandler(async (req, res) => {
-  const { sortBy, order } = sortSchema.parse(req.query);
-  const validColumns = Object.values(DB_COLUMNS.PROJECT);
-  const sortFields = sortBy?.split(',') || [];
-  const sortOrders = order?.split(',') || [];
-
-  const invalidFields = sortFields.filter(
-    (field) => !validColumns.includes(field),
-  );
-  if (invalidFields.length > 0) {
-    res.status(BAD_REQUEST).json({
-      message: `Invalid sort field(s): ${invalidFields.join(', ')}. Allowed fields: ${validColumns.join(', ')}`,
-    });
-    return;
-  }
-
-  const orderBy: ISortQuery = sortFields.map((field, index) => ({
-    [field]: sortOrders[index]?.toLocaleLowerCase() === 'desc' ? 'desc' : 'asc',
-  }));
-
-  const projects = await projectService.findMany(
-    { userUuid: req.user?.uuid as string },
-    orderBy.length > 0 ? orderBy : undefined,
-  );
+  const projects = await projectService.findMany({
+    userUuid: req.user?.uuid as string,
+  });
 
   res
     .status(OK)

--- a/src/repositories/project.repository.ts
+++ b/src/repositories/project.repository.ts
@@ -1,6 +1,5 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 import { prismaClient } from '../database';
-import { ISortQuery } from '../types';
 
 export class ProjectRepository {
   constructor(private readonly dbClient: PrismaClient) {}
@@ -13,8 +12,11 @@ export class ProjectRepository {
     return this.dbClient.project.findUnique({ where: query });
   }
 
-  async findMany(query: Prisma.ProjectWhereInput, orderBy?: ISortQuery) {
-    return this.dbClient.project.findMany({ where: query, orderBy });
+  async findMany(query: Prisma.ProjectWhereInput) {
+    return this.dbClient.project.findMany({
+      where: query,
+      orderBy: { createdAt: 'asc' },
+    });
   }
 
   async updateOne(

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -1,6 +1,5 @@
 import { Prisma } from '@prisma/client';
 import { projectRepository } from '../repositories';
-import { ISortQuery } from '../types';
 import { ApiError, NOT_FOUND } from '../utils';
 
 export class ProjectService {
@@ -14,8 +13,8 @@ export class ProjectService {
     return this.projectDataSource.findOne(query);
   }
 
-  async findMany(query: Prisma.ProjectWhereInput, sort?: ISortQuery) {
-    return this.projectDataSource.findMany(query, sort);
+  async findMany(query: Prisma.ProjectWhereInput) {
+    return this.projectDataSource.findMany(query);
   }
 
   async updateOne(


### PR DESCRIPTION
### Refactoring and simplification of project retrieval

* Removed dynamic sorting logic and validation from `getAllProjects` in `project.controller.ts`; projects are now always sorted by creation date in ascending order.
* Updated `ProjectRepository.findMany` to always sort by `createdAt: 'asc'`, removing the optional sorting parameter.
