### PR TITLE
(CI) Ignore paths in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.dockerignore'
+      - 'LICENSE'
+      - '.vscode/**'
+      - 'swagger.json'
 
 jobs:
   build:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "🔍 Checking changed files..."
-CHANGED_FILES=$(git diff --name-only HEAD@{1} HEAD)
+CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
 
 IGNORED_PATTERNS='(\.md$|^docs/|\.gitignore$|\.dockerignore$|^\.vscode/|^LICENSE$|^swagger\.json$)'
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+echo "🔍 Checking changed files..."
+CHANGED_FILES=$(git diff --name-only HEAD@{1} HEAD)
+
+IGNORED_PATTERNS='(\.md$|^docs/|\.gitignore$|\.dockerignore$|^\.vscode/|^LICENSE$|^swagger\.json$)'
+
+if echo "$CHANGED_FILES" | grep -qvE "$IGNORED_PATTERNS"; then
+  echo "💡 Code-related changes detected → running full deploy process"
+else
+  echo "📝 Docs-only or ignored changes detected → syncing without build"
+  git pull origin main
+  exit 0
+fi
+
 echo "🔄 Pulling latest code..."
 git pull origin main
 


### PR DESCRIPTION
This PR updates the CI workflow configuration to avoid running the workflow for documentation or config-only changes. This helps reduce unnecessary CI runs and speeds up the development process.

CI workflow improvements:

* Added `paths-ignore` for documentation files, config files, and other non-code assets, so the workflow is only triggered for relevant code changes.