### PR TITLE
(Hot Fix): Update axios version to 1.12.1 duo to vulnerability issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bull-board/api": "^6.12.7",
         "@bull-board/express": "^6.12.7",
         "@prisma/client": "^6.3.1",
-        "axios": "^1.8.4",
+        "axios": "^1.12.1",
         "bcryptjs": "^2.4.3",
         "bullmq": "^5.45.2",
         "cloudinary": "^2.5.1",
@@ -31,7 +31,6 @@
         "multer": "^2.0.2",
         "node-cron": "^3.0.3",
         "nodemailer": "^6.10.0",
-        "prom-client": "^14.0.0",
         "redis": "^4.7.0",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.17.0",
@@ -1330,13 +1329,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
+      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1398,12 +1397,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/bintrees": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -4518,18 +4511,6 @@
         }
       }
     },
-    "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5214,15 +5195,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/tdigest": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
-      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
-      "license": "MIT",
-      "dependencies": {
-        "bintrees": "1.0.2"
       }
     },
     "node_modules/text-hex": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@bull-board/api": "^6.12.7",
     "@bull-board/express": "^6.12.7",
     "@prisma/client": "^6.3.1",
-    "axios": "^1.8.4",
+    "axios": "^1.12.1",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.45.2",
     "cloudinary": "^2.5.1",


### PR DESCRIPTION
This pull request updates the `axios` dependency in the `package.json` file to a newer version. This is a minor change that helps keep dependencies up to date and may include important bug fixes and security patches. 

- Updated the `axios` package version from `^1.8.4` to `^1.12.1` in `package.json`